### PR TITLE
In TemporaryStorage, prevented user from inputing more text than allo…

### DIFF
--- a/src/gui/design.py
+++ b/src/gui/design.py
@@ -166,7 +166,7 @@ class StartGui(GuiTemplate):
         tag_input = self.tag_entry.get()
         logger.debug(f"Auto-clearing tag-entry \"{tag_input}\"")
         self.tag_entry.delete(0, 'end')
- 
+
     def cancel_cleanup_timeout(self):
         if self.debouncer is not None:
             self.frame.after_cancel(self.debouncer)
@@ -207,14 +207,22 @@ class MemberInformation(GuiTemplate):
 class TemporaryStorage(GuiTemplate):
 
     def text_box_callback_key(self, event):
-        text_box_length = len(self.text_box.get('1.0', END)) - 1
-        self.character_label_string.set(f'{text_box_length} / {MAX_DESCRIPTION_LENGTH}')
+        text_box_content = self.text_box.get('1.0', END)
+        text_box_length = len(text_box_content) - 1
         self.timeout_timer_reset()
 
-        if text_box_length > MAX_DESCRIPTION_LENGTH:
-            self.character_label.config(fg='red')
+        if text_box_length >= MAX_DESCRIPTION_LENGTH:
+            self.text_box.delete('1.0', END)
+            self.text_box.insert('1.0', text_box_content[:MAX_DESCRIPTION_LENGTH])
         else:
             self.character_label.config(fg='grey')
+
+        self.character_label_update()
+
+    def character_label_update(self):
+        text_box_content = self.text_box.get('1.0', END)
+        text_box_length = len(text_box_content) - 1
+        self.character_label_string.set(f'{text_box_length} / {MAX_DESCRIPTION_LENGTH}')
 
     def text_box_callback_focusin(self, event):
         self.text_box.config(fg='black')

--- a/src/label/creator.py
+++ b/src/label/creator.py
@@ -77,7 +77,7 @@ def create_temporary_storage_label(member_id, name, description):
     date_text_size, date_font = get_font_size(300, date_text)
 
     # Special solution due to multiline text.
-    description_text = textwrap.fill(description, 40, break_long_words=False)
+    description_text = textwrap.fill(description, 40, break_long_words=True)
     description_font_point_size = 140
     description_font = ImageFont.truetype(config.FONT_PATH, description_font_point_size)
 


### PR DESCRIPTION
…wed and added automatic wrapping on text for labels 

This is a solution for #26, see the result below. 

![9999_1556039219](https://user-images.githubusercontent.com/4609724/56601680-1598a500-65fc-11e9-962d-3689560292fa.png)




