### PR TITLE
Development flag defaults

### DIFF
--- a/memberbooth.py
+++ b/memberbooth.py
@@ -25,7 +25,7 @@ def main():
         ("printer", False),
         ("input_method", INPUT_KEYBOARD),
         ("backend", False)])
-    boolean_use_action = parser_util.BooleanOptionalAction("use", "no")
+    boolean_use_action = parser_util.BooleanOptionalActionFactory("use", "no")
 
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)

--- a/memberbooth.py
+++ b/memberbooth.py
@@ -43,11 +43,8 @@ def main():
 
     ns = parser.parse_args()
 
-    print(ns)
-    sys.exit(0)
-
-    config.no_backend = ns.no_backend
-    config.no_printer = ns.no_printer
+    config.no_backend = not ns.backend
+    config.no_printer = not ns.printer
     config.development = ns.development
     config.token_path = ns.token_path
     config.maker_admin_base_url = ns.maker_admin_base_url

--- a/memberbooth.py
+++ b/memberbooth.py
@@ -17,18 +17,37 @@ INPUT_EM4100 = "EM4100"
 INPUT_APTUS  = "Aptus-reader"
 INPUT_KEYBOARD = "Keyboard"
 
+class DevelopmentAction(argparse.Action):
+    ARG_OVERRIDES = (
+            ("maker_admin_base_url", "http://localhost:8010"),
+            ("no_printer", True),
+            ("input_method", INPUT_KEYBOARD),
+            ("no_backend", True),
+        )
+
+    def __init__(self, option_strings, dest, nargs=None, const=None, default=None, type=None, choices=None, required=None, help=None, metavar=None):
+        nargs = 0
+        super(DevelopmentAction, self).__init__(option_strings, dest, nargs, const, default, type, choices, required, help, metavar)
+
+    def __call__(self, parser, ns, values, option_string=None):
+        setattr(ns, self.dest, values)
+        for dest, value in self.ARG_OVERRIDES:
+            setattr(ns, dest, value)
+
 def main():
     logger.info(f"Starting {sys.argv[0]} as \n\t{start_command}")
 
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("-t", "--token_path", help="Path to Makeradmin token.", default=config.token_path)
-    group.add_argument("--development", action="store_true", help="Mock events")
+    group.add_argument("--development", action=DevelopmentAction, help="Mock events. Add common development flags.")
     parser.add_argument("-u", "--maker-admin-base-url",
                         default=config.maker_admin_base_url,
                         help="Base url of maker admin backend")
     parser.add_argument("--no-backend", action="store_true", help="Mock backend (fake requests)")
+    parser.add_argument("--use-backend", dest="no_backend", action="store_false", help="Do not mock backend")
     parser.add_argument("--no-printer", action="store_true", help="Mock label printer (save label to file instead)")
+    parser.add_argument("--use-printer", dest="no_printer", action="store_false", help="Do not mock label printer")
     parser.add_argument("--input-method", choices=(INPUT_EM4100, INPUT_APTUS, INPUT_KEYBOARD), default=INPUT_EM4100, help="The method to input the key")
 
     parser.add_argument("--slack-token-path", help="Path to Slack token.", default=config.slack_token_path)

--- a/memberbooth.py
+++ b/memberbooth.py
@@ -22,9 +22,10 @@ def main():
     logger.info(f"Starting {sys.argv[0]} as \n\t{start_command}")
     development_override_action = parser_util.DevelopmentOverrideActionFactory([
         ("maker_admin_base_url", "http://localhost:8010"),
-        ("no_printer", True),
+        ("printer", False),
         ("input_method", INPUT_KEYBOARD),
-        ("no_backend", True)])
+        ("backend", False)])
+    boolean_use_action = parser_util.BooleanOptionalAction("use", "no")
 
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group(required=True)
@@ -33,8 +34,8 @@ def main():
     parser.add_argument("-u", "--maker-admin-base-url",
                         default=config.maker_admin_base_url,
                         help="Base url of maker admin backend")
-    parser.add_argument("--backend", action=parser_util.BooleanOptionalAction, help="Whether to use real backend or fake requests")
-    parser.add_argument("--printer", action=parser_util.BooleanOptionalAction, help="Whether to use real label printer or save label to file instead")
+    parser.add_argument("--backend", action=boolean_use_action, default=True, help="Whether to use real backend or fake requests")
+    parser.add_argument("--printer", action=boolean_use_action, default=True, help="Whether to use real label printer or save label to file instead")
     parser.add_argument("--input-method", choices=(INPUT_EM4100, INPUT_APTUS, INPUT_KEYBOARD), default=INPUT_EM4100, help="The method to input the key")
 
     parser.add_argument("--slack-token-path", help="Path to Slack token.", default=config.slack_token_path)

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -14,7 +14,7 @@ def DevelopmentOverrideActionFactory(overrides):
     return DevelopmentOverrideAction
 
 # Taken from https://github.com/python/cpython/blob/b4e5eeac267c436bb60776dc5be771d3259bd298/Lib/argparse.py#L856-L895
-def BooleanOptionalAction(assertive_prefix="use-", deassertive_prefix="no-"):
+def BooleanOptionalActionFactory(assertive_prefix="use-", deassertive_prefix="no-"):
     def format_prefix(prefix):
         if not prefix.startswith("--"):
             prefix = "--" + prefix

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -14,44 +14,77 @@ def DevelopmentOverrideActionFactory(overrides):
     return DevelopmentOverrideAction
 
 # Taken from https://github.com/python/cpython/blob/b4e5eeac267c436bb60776dc5be771d3259bd298/Lib/argparse.py#L856-L895
-class BooleanOptionalAction(argparse.Action):
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 const=None,
-                 default=None,
-                 type=None,
-                 choices=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
+def BooleanOptionalAction(assertive_prefix="use-", deassertive_prefix="no-"):
+    def format_prefix(prefix):
+        if not prefix.startswith("--"):
+            prefix = "--" + prefix
+        if not prefix.endswith("-"):
+            prefix = prefix + "-"
+        return prefix
 
-        _option_strings = []
-        for option_string in option_strings:
-            _option_strings.append(option_string)
+    assertive_prefix   = format_prefix(assertive_prefix)
+    deassertive_prefix = format_prefix(deassertive_prefix)
 
-            if option_string.startswith('--'):
-                option_string = '--no-' + option_string[2:]
-                _option_strings.append(option_string)
+    class BooleanOptionalAction(argparse.Action):
+        def __init__(self,
+                     option_strings,
+                     dest,
+                     const=None,
+                     default=None,
+                     choices=None,
+                     required=False,
+                     help=None,
+                     metavar=None):
 
-        if help is not None and default is not None:
-            help += f" (default: {default})"
+            assert isinstance(default, bool), "Default value must be of bool type"
 
-        super().__init__(
-            option_strings=_option_strings,
-            dest=dest,
-            nargs=0,
-            default=default,
-            type=type,
-            choices=choices,
-            required=required,
-            help=help,
-            metavar=metavar)
+            self.assertive_prefix   = assertive_prefix
+            self.deassertive_prefix = deassertive_prefix
 
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string in self.option_strings:
-            setattr(namespace, self.dest, not option_string.startswith('--no-'))
+            _option_strings = []
+            for option_string in option_strings:
+                if not option_string.startswith('--'):
+                    raise ValueError("BooleanOptionalAction must be an optional argument (i.e. start with --)")
 
-    def format_usage(self):
-        return ' | '.join(self.option_strings)
+                optname = option_string[2:]
+
+                if option_string.startswith(self.assertive_prefix):
+                    self.assertive_opt   = option_string
+                    self.deassertive_opt = deassertive_prefix + optname[len(self.assertive_prefix):]
+                elif option_string.startswith(self.deassertive_prefix):
+                    self.assertive_opt   = assertive_prefix + optname[len(self.deassertive_prefix):]
+                    self.deassertive_opt = option_string
+                else:
+                    self.assertive_opt   = assertive_prefix + optname
+                    self.deassertive_opt = deassertive_prefix + optname
+
+                if default:
+                    _option_strings.append(self.deassertive_opt)
+                    _option_strings.append(self.assertive_opt)
+                else:
+                    _option_strings.append(self.assertive_opt)
+                    _option_strings.append(self.deassertive_opt)
+
+            if help is not None and default is not None:
+                help += f" (default: {default})"
+
+            super().__init__(
+                option_strings=_option_strings,
+                dest=dest,
+                nargs=0,
+                default=default,
+                type=bool,
+                choices=choices,
+                required=required,
+                help=help,
+                metavar=metavar)
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            if option_string in self.option_strings:
+                setattr(namespace, self.dest, not option_string.startswith(self.deassertive_prefix))
+
+        def format_usage(self):
+            return ' | '.join(self.option_strings)
+
+    return BooleanOptionalAction
 

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -1,0 +1,57 @@
+import argparse
+
+def DevelopmentOverrideActionFactory(overrides):
+    class DevelopmentOverrideAction(argparse.Action):
+        ARG_OVERRIDES = overrides
+
+        def __init__(self, option_strings, dest, help=None):
+            super().__init__(option_strings, dest, nargs=0)
+
+        def __call__(self, parser, ns, values, option_string=None):
+            setattr(ns, self.dest, values)
+            for dest, value in self.ARG_OVERRIDES:
+                setattr(ns, dest, value)
+    return DevelopmentOverrideAction
+
+# Taken from https://github.com/python/cpython/blob/b4e5eeac267c436bb60776dc5be771d3259bd298/Lib/argparse.py#L856-L895
+class BooleanOptionalAction(argparse.Action):
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 const=None,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar=None):
+
+        _option_strings = []
+        for option_string in option_strings:
+            _option_strings.append(option_string)
+
+            if option_string.startswith('--'):
+                option_string = '--no-' + option_string[2:]
+                _option_strings.append(option_string)
+
+        if help is not None and default is not None:
+            help += f" (default: {default})"
+
+        super().__init__(
+            option_strings=_option_strings,
+            dest=dest,
+            nargs=0,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            setattr(namespace, self.dest, not option_string.startswith('--no-'))
+
+    def format_usage(self):
+        return ' | '.join(self.option_strings)
+


### PR DESCRIPTION
Solves #42 by making `--development` flag to set several attributes at once in the `argparse.Namespace` object.
It also adds the required `--use-...` flags to assert options that had been deasserted by the `--development` flag. E.g. `./memberbooth --development --use-printer` would make the program to actually use the printer, even though the `--development` flag set it to not to.