### PR TITLE
Refactor MakerAdminClient to use TokenConfiguredClient

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 
-no_backend = False
+# Program flags
 no_printer = False
 development = False
-token_path = "ramdisk/.token"
+
+# Common init values of argument parsers
+makeradmin_token_path = "ramdisk/.makeradmin_token"
 slack_token_path = "ramdisk/.slack_token"
 logger_name = 'memberbooth'
 maker_admin_base_url = 'https://api.makerspace.se'
 
+# Nice to have constants
 _DIR = Path(__file__).parent.absolute()
 RESOURCES_PATH = _DIR.joinpath('resources/')
 LOGOTYPE_PATH = str(RESOURCES_PATH.joinpath('sms_logotype_gui.png'))

--- a/login.py
+++ b/login.py
@@ -31,10 +31,10 @@ def main():
 
     token = ""
     if Path(ns.makeradmin_token_path).is_file():
-        with open(ns.token_file) as f:
+        with open(ns.makeradmin_token_path) as f:
             token = f.read()
 
-    client = MakerAdminClient(ns.maker_admin_base_url, ns.token_file, token)
+    client = MakerAdminClient(ns.maker_admin_base_url, ns.makeradmin_token_path, token)
     while not client.is_logged_in():
         try:
             client.login()

--- a/login.py
+++ b/login.py
@@ -34,7 +34,7 @@ def main():
         with open(ns.token_file) as f:
             token = f.read()
 
-    client = MakerAdminClient(ns.maker_admin_base_url, token)
+    client = MakerAdminClient(ns.maker_admin_base_url, ns.token_file, token)
     while not client.is_logged_in():
         try:
             client.login()

--- a/login.py
+++ b/login.py
@@ -26,11 +26,11 @@ def main():
     parser.add_argument("-u", "--maker-admin-base-url",
                         default=config.maker_admin_base_url,
                         help="Base url of maker admin backend")
-    parser.add_argument("--token-file", default=config.token_path, help="File that contains Makeradmin token")
+    parser.add_argument("--makeradmin-token-path", "-t", help="Path to Makeradmin token", default=config.makeradmin_token_path)
     ns = parser.parse_args()
 
     token = ""
-    if Path(ns.token_file).is_file():
+    if Path(ns.makeradmin_token_path).is_file():
         with open(ns.token_file) as f:
             token = f.read()
 
@@ -44,7 +44,7 @@ def main():
     token = client.token
     logger.info(f"Logged in with token: {token}")
 
-    token_dir = Path(config.token_path).parent
+    token_dir = Path(config.makeradmin_token_path).parent
     token_dir.mkdir(exist_ok=True)
     if ramdisk_is_mounted(token_dir):
         logger.warning("RAM-disk is already mounted. Unmounting.")
@@ -56,9 +56,9 @@ def main():
     if not ramdisk_is_mounted(token_dir):
         raise TypeError(f"Failed to mount a RAM-disk to {token_dir}...")
 
-    logger.info(f"Creating token file '{config.token_path}'")
-    with open(config.token_path, "w") as f:
-        os.chmod(config.token_path, stat.S_IRUSR | stat.S_IWUSR)
+    logger.info(f"Creating token file '{config.makeradmin_token_path}'")
+    with open(config.makeradmin_token_path, "w") as f:
+        os.chmod(config.makeradmin_token_path, stat.S_IRUSR | stat.S_IWUSR)
         f.write(token)
 
     print("Login successful")

--- a/memberbooth.py
+++ b/memberbooth.py
@@ -59,7 +59,7 @@ def main():
         sys.exit(-1)
 
     if ns.no_backend:
-        makeradmin_client = makeradmin_mock.MakerAdminClient(base_url=config.maker_admin_base_url, token=config.makeradmin_token_path)
+        makeradmin_client = MockedMakerAdminClient(base_url=config.maker_admin_base_url, token=config.makeradmin_token_path)
     else:
         makeradmin_client = MakerAdminClient(base_url=ns.maker_admin_base_url, token_path=ns.makeradmin_token_path)
 

--- a/memberbooth.py
+++ b/memberbooth.py
@@ -34,7 +34,7 @@ def main():
     parser.add_argument("--input-method", choices=(INPUT_EM4100, INPUT_APTUS, INPUT_KEYBOARD), default=INPUT_EM4100, help="The method to input the key")
 
     token_group = parser.add_argument_group(description="Tokens")
-    token_group.add_argument("--makeradmin-token-path", help="Path to Makeradmin token", default=config.makeradmin_token_path)
+    token_group.add_argument("--makeradmin-token-path", "-t", help="Path to Makeradmin token", default=config.makeradmin_token_path)
     token_group.add_argument("--slack-token-path", help="Path to Slack token.", default=config.slack_token_path)
     token_group.add_argument("--slack-channel-id", help="Channel id for Slack channel")
 
@@ -59,7 +59,7 @@ def main():
         sys.exit(-1)
 
     if ns.no_backend:
-        makeradmin_client = MockedMakerAdminClient(base_url=config.maker_admin_base_url, token=config.makeradmin_token_path)
+        makeradmin_client = MockedMakerAdminClient(base_url=config.maker_admin_base_url, token_path=ns.makeradmin_token_path)
     else:
         makeradmin_client = MakerAdminClient(base_url=ns.maker_admin_base_url, token_path=ns.makeradmin_token_path)
 

--- a/src/backend/makeradmin.py
+++ b/src/backend/makeradmin.py
@@ -25,7 +25,7 @@ class MakerAdminClient(TokenConfiguredClient):
 
     def try_log_in(self):
         if not self.is_logged_in():
-            raise TokenExpiredError()
+            raise MakerAdminTokenExpiredError()
 
     def _request(self, subpage, data={}):
         url = self.base_url + subpage
@@ -34,7 +34,7 @@ class MakerAdminClient(TokenConfiguredClient):
 
     @TokenConfiguredClient.require_configured_factory(default_retval=dict(ok=False))
     def request(self, subpage, data={}):
-        self._request(subpage, data)
+        return self._request(subpage, data)
 
     def is_logged_in(self):
         if not self.token:

--- a/src/backend/makeradmin.py
+++ b/src/backend/makeradmin.py
@@ -1,28 +1,45 @@
 import requests
 from src.util.logger import get_logger
 from json.decoder import JSONDecodeError
+from src.util.token_config import TokenConfiguredClient, TokenExpiredError
 from getpass import getpass
 import sys
 
 logger = get_logger()
 
-class MakerAdminClient(object):
+class MakerAdminTokenExpiredError(TokenExpiredError):
+    pass
+
+class MakerAdminClient(TokenConfiguredClient):
     TAG_URL = "/multiaccess/memberbooth/tag"
     MEMBER_NUMBER_URL = '/multiaccess/memberbooth/member'
 
-    def __init__(self, base_url=None, token=""):
+    def __init__(self, base_url, token_path, token=None):
         self.base_url = base_url
+        self.token_path = token_path
+        if token:
+            self.configure_client(token)
+
+    def configure_client(self, token):
         self.token = token
 
-    def request(self, subpage, data={}):
+    def try_log_in(self):
+        if not self.is_logged_in():
+            raise TokenExpiredError()
+
+    def _request(self, subpage, data={}):
         url = self.base_url + subpage
         r = requests.get(url, headers={'Authorization': 'Bearer ' + self.token}, data=data)
         return r
 
+    @TokenConfiguredClient.require_configured_factory(default_retval=dict(ok=False))
+    def request(self, subpage, data={}):
+        self._request(subpage, data)
+
     def is_logged_in(self):
         if not self.token:
             return False
-        r = self.request(self.TAG_URL, {"tagid": 0})
+        r = self._request(self.TAG_URL, {"tagid": 0})
         if not r.ok:
             data = r.json()
             logger.info(f"Token not logged in with correct permissions. Got: '{data}'")

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -146,6 +146,8 @@ class WaitingState(State):
                 self.gui.reset_gui()
                 self.gui.show_error_message("Could not find a member that matches the specific tag")
                 state = self
+            except MakerAdminClientTokenExpired:
+                state = WaitingForTokenState(self, self.member)
             except Exception as e:
                 logger.error(f"Exception raised {e}")
                 traceback.print_exception(*sys.exc_info())
@@ -282,22 +284,7 @@ class WaitingForTokenState(State):
 
     #TODO Do cleanup if not logged_in and restart timer.
     def token_reader_timer_expired(self):
-        if config.no_backend:
-            self.application.makeradmin_client = makeradmin_mock.MakerAdminClient(base_url=config.maker_admin_base_url, token=config.token_path)
-            self.application.on_event(Event(Event.MAKERADMIN_CLIENT_CONFIGURED))
-
-        elif Path(config.token_path).is_file():
-            f = open(config.token_path, 'r')
-            maker_admin_token = f.read()
-            f.close()
-            logger.info(f"maker_admin_token was read successfully")
-
-            self.application.makeradmin_client = makeradmin.MakerAdminClient(base_url=config.maker_admin_base_url, token=maker_admin_token)
-            logged_in = self.application.makeradmin_client.is_logged_in()
-            logger.info(f"Logged in: {logged_in}")
-            if not logged_in:
-                logger.error("The makeradmin client is not logged in")
-                sys.exit(-1)
+        if self.application.makeradmin_client.configured:
             self.application.on_event(Event(Event.MAKERADMIN_CLIENT_CONFIGURED))
         else:
             self.token_reader_timer_start()
@@ -329,10 +316,10 @@ class Application(object):
     def notbusy(self):
         self.master.config(cursor='')
 
-    def __init__(self, key_reader, slack_client):
+    def __init__(self, key_reader, makeradmin_client, slack_client):
 
-        self.makeradmin_client = None
         self.key_reader = key_reader
+        self.makeradmin_client = makeradmin_client
         self.slack_client = slack_client
 
         tk = Tk()

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -4,11 +4,9 @@ from .design import GuiEvent, StartGui, MemberInformation, TemporaryStorage, Wai
 from src.label import creator as label_creator
 from src.label import printer as label_printer
 from src.util.logger import get_logger
-from src.util.slack_client import SlackClient
 from traceback import print_exc
-from src.backend import makeradmin
-from src.test import makeradmin_mock
-from src.backend.member import Member, NoMatchingTagId, NoMatchingMemberNumber
+from src.backend.makeradmin import MakerAdminTokenExpiredError
+from src.backend.member import Member, NoMatchingTagId
 from src.util.key_reader import EM4100
 from re import compile, search, sub
 from time import time
@@ -146,7 +144,7 @@ class WaitingState(State):
                 self.gui.reset_gui()
                 self.gui.show_error_message("Could not find a member that matches the specific tag")
                 state = self
-            except MakerAdminClientTokenExpired:
+            except MakerAdminTokenExpiredError:
                 state = WaitingForTokenState(self, self.member)
             except Exception as e:
                 logger.error(f"Exception raised {e}")

--- a/src/test/makeradmin_mock.py
+++ b/src/test/makeradmin_mock.py
@@ -16,6 +16,10 @@ class MakerAdminClient(object):
     def __init__(self, *args, **kwargs):
         pass
 
+    @property
+    def configured(self):
+        return True
+
     def is_logged_in(self):
         return True
 

--- a/src/util/slack_client.py
+++ b/src/util/slack_client.py
@@ -34,7 +34,7 @@ class SlackClient(TokenConfiguredClient):
             logger.error(f"SlackClient failed with error: {e}")
             raise SlackTokenExpiredError(str(e))
 
-    @TokenConfiguredClient.require_configured
+    @TokenConfiguredClient.require_configured_factory()
     def post_message(self, msg):
         try:
             self._post_message(msg)


### PR DESCRIPTION
Using the file-reading `TokenConfiguredClient` in `MakedAdminClient` as well (as used in `SlackClient`).