### PR TITLE
Serial port disconnect/reconnect handling

### DIFF
--- a/memberbooth.py
+++ b/memberbooth.py
@@ -53,15 +53,11 @@ def main():
     no_slack = not ns.slack
 
     if ns.input_method == INPUT_EM4100:
-        try:
-            key_reader = EM4100.get_reader()
-        except NoReaderFound as e:
-            logger.error("No EM4100 tag reader is connected. Connect one and try again.")
-            sys.exit(-1)
+        key_reader_class = EM4100
     elif ns.input_method == INPUT_APTUS:
-        key_reader = Aptus.get_reader()
+        key_reader_class = Aptus
     elif ns.input_method == INPUT_KEYBOARD:
-        key_reader = Keyboard.get_reader()
+        key_reader_class = Keyboard
     else:
         logger.error(f"Invalid input method: {ns.input_method}")
         sys.exit(-1)
@@ -76,7 +72,7 @@ def main():
     else:
         slack_client = SlackClient(token_path=ns.slack_token_path, channel_id=ns.slack_channel_id)
 
-    app = Application(key_reader, makeradmin_client, slack_client)
+    app = Application(key_reader_class, makeradmin_client, slack_client)
     try:
         app.run()
     except KeyboardInterrupt:

--- a/src/gui/design.py
+++ b/src/gui/design.py
@@ -305,3 +305,10 @@ class WaitForTokenGui(GuiTemplate):
         self.progress_bar.stop()
         self.progress_bar.pack_forget()
 
+class WaitForKeyReaderReadyGui(GuiTemplate):
+    def __init__(self, master):
+        super().__init__(master, None)
+        self.scan_tag_label = self.create_label(self.frame, 'Connect key reader...')
+        self.scan_tag_label.pack(fill=X, pady=5)
+        self.frame.pack(pady=25)
+

--- a/src/gui/event.py
+++ b/src/gui/event.py
@@ -20,6 +20,7 @@ class Event(BaseEvent):
     CANCEL = 'event_cancel'
     PRINTING_FAILED = 'event_printing_failed'
     PRINTING_SUCCEEDED = 'event_printing_succeeded'
+    SERIAL_PORT_DISCONNECTED = 'event_serial_port_disconnected'
 
 class GuiEvent(BaseEvent):
 

--- a/src/gui/event.py
+++ b/src/gui/event.py
@@ -21,6 +21,7 @@ class Event(BaseEvent):
     PRINTING_FAILED = 'event_printing_failed'
     PRINTING_SUCCEEDED = 'event_printing_succeeded'
     SERIAL_PORT_DISCONNECTED = 'event_serial_port_disconnected'
+    KEY_READER_CONNECTED = 'event_key_reader_connected'
 
 class GuiEvent(BaseEvent):
 

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -308,8 +308,7 @@ class WaitForKeyReaderReadyState(State):
         super().__init__(*args)
         self.gui = WaitForKeyReaderReadyGui(self.master)
 
-        self.check_reader_connected_timeout = None
-        self.check_key_reader_ready()
+        self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
 
     def check_key_reader_ready(self):
         try:
@@ -321,8 +320,7 @@ class WaitForKeyReaderReadyState(State):
     def on_event(self, event):
         event_type = event.event
         if event_type == Event.KEY_READER_CONNECTED:
-            if self.check_reader_connected_timeout is not None:
-                self.master.after_cancel(self.check_reader_connected_timeout)
+            self.master.after_cancel(self.check_reader_connected_timeout)
             return WaitingState(self.application, self.master)
 
 class Application(object):

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -7,7 +7,7 @@ from src.util.logger import get_logger
 from traceback import print_exc
 from src.backend.makeradmin import MakerAdminTokenExpiredError
 from src.backend.member import Member, NoMatchingTagId
-from src.util.key_reader import EM4100, NoReaderFound
+from src.util.key_reader import EM4100, NoReaderFound, KeyReaderNeedsRebootError
 import termios
 import serial.serialutil
 from re import compile, search, sub
@@ -316,6 +316,8 @@ class WaitForKeyReaderReadyState(State):
         try:
             self.application.key_reader = self.application.key_reader_class.get_reader()
             self.application.on_event(Event(Event.KEY_READER_CONNECTED))
+        except KeyReaderNeedsRebootError:
+            self.gui.show_error_message("The key reader has hanged. Unplug it and plug it in again.")
         except NoReaderFound:
             self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
 

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -318,6 +318,7 @@ class WaitForKeyReaderReadyState(State):
             self.application.on_event(Event(Event.KEY_READER_CONNECTED))
         except KeyReaderNeedsRebootError:
             self.gui.show_error_message("The key reader has hanged. Unplug it and plug it in again.")
+            self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
         except NoReaderFound:
             self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
 

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -1,13 +1,13 @@
 from tkinter import Tk
 from .event import Event
-from .design import GuiEvent, StartGui, MemberInformation, TemporaryStorage, WaitForTokenGui
+from .design import GuiEvent, StartGui, MemberInformation, TemporaryStorage, WaitForTokenGui, WaitForKeyReaderReadyGui
 from src.label import creator as label_creator
 from src.label import printer as label_printer
 from src.util.logger import get_logger
 from traceback import print_exc
 from src.backend.makeradmin import MakerAdminTokenExpiredError
 from src.backend.member import Member, NoMatchingTagId
-from src.util.key_reader import EM4100
+from src.util.key_reader import EM4100, NoReaderFound
 import termios
 import serial.serialutil
 from re import compile, search, sub
@@ -138,7 +138,6 @@ class WaitingState(State):
     def on_event(self, event):
         super().on_event(event)
 
-        state = self
         event_type = event.event
 
         if event_type == Event.TAG_READ:
@@ -147,26 +146,20 @@ class WaitingState(State):
             try:
                 tagid = event.data
                 self.member = Member.from_tagid(self.application.makeradmin_client, tagid)
-                state = MemberIdentified(self.application, self.master, self.member)
+                return MemberIdentified(self.application, self.master, self.member)
             except NoMatchingTagId as e:
                 self.gui.reset_gui()
                 self.gui.show_error_message("Could not find a member that matches the specific tag")
-                state = self
             except MakerAdminTokenExpiredError:
-                state = WaitingForTokenState(self, self.member)
+                return WaitingForTokenState(self, self.member)
             except Exception as e:
                 logger.error(f"Exception raised {e}")
                 traceback.print_exception(*sys.exc_info())
                 self.gui.show_error_message(f"Error... \n{e}")
                 self.gui.reset_gui()
-                state = self
 
         elif event_type == Event.SERIAL_PORT_DISCONNECTED:
-            state = WaitingState(self.application, self.master)
-
-        if state is not self:
-            self.change_state()
-        return state
+            return WaitingState(self.application, self.master)
 
 class EditTemporaryStorageLabel(State):
 
@@ -205,18 +198,12 @@ class EditTemporaryStorageLabel(State):
     def on_event(self, event):
         super().on_event(event)
 
-        state = self
         event = event.event
-
         if event == Event.CANCEL or event == Event.PRINTING_SUCCEEDED:
-            state = MemberIdentified(self.application, self.master, self.member)
+            return MemberIdentified(self.application, self.master, self.member)
 
         elif event == Event.LOG_OUT:
-            state = WaitingState(self.application, self.master, None)
-
-        if state is not self:
-            self.change_state()
-        return state
+            return WaitingState(self.application, self.master, None)
 
 class MemberIdentified(State):
 
@@ -268,18 +255,12 @@ class MemberIdentified(State):
     def on_event(self, event):
         super().on_event(event)
 
-        state = self
         event = event.event
-
         if event == Event.LOG_OUT:
-            state = WaitingState(self.application, self.master)
+            return WaitingState(self.application, self.master)
 
         elif event == Event.PRINT_TEMPORARY_STORAGE_LABEL:
-            state = EditTemporaryStorageLabel(self.application, self.master, self.member)
-
-        if state is not self:
-            self.change_state()
-        return state
+            return EditTemporaryStorageLabel(self.application, self.master, self.member)
 
 
 class WaitingForTokenState(State):
@@ -319,15 +300,33 @@ class WaitingForTokenState(State):
     def on_event(self, event):
         super().on_event(event)
 
-        state = self
         event_type = event.event
-
         if event_type == Event.MAKERADMIN_CLIENT_CONFIGURED:
-            state = WaitingState(self.application, self.master, self.member)
+            return WaitForKeyReaderReadyState(self.application, self.master)
 
-        if state is not self:
-            self.change_state()
-        return state
+class WaitForKeyReaderReadyState(State):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.gui = WaitForKeyReaderReadyGui(self.master)
+
+        self.check_reader_connected_timeout = None
+        self.check_key_reader_ready()
+
+    def check_key_reader_ready(self):
+        try:
+            key_reader = self.application.key_reader.__class__.get_reader()
+            self.application.on_event(Event(Event.KEY_READER_CONNECTED))
+        except NoReaderFound:
+            pass
+
+        self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
+
+    def on_event(self, event):
+        event_type = event.event
+        if event_type == Event.KEY_READER_CONNECTED:
+            if self.check_reader_connected_timeout is not None:
+                self.master.after_cancel(self.check_reader_connected_timeout)
+            return WaitingState(self.application, self.master, self.member)
 
 class Application(object):
 
@@ -356,7 +355,10 @@ class Application(object):
             self.master.bind('<A>', lambda e:self.on_event(Event(Event.TAG_READ)))
 
     def on_event(self, event):
-        self.state = self.state.on_event(event)
+        next_state = self.state.on_event(event)
+        if next_state is not None and next_state is not self.state:
+            self.state.change_state()
+            self.state = next_state
 
     def run(self):
         self.slack_client.post_message_alert("Application was restarted!")

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -278,7 +278,6 @@ class WaitingForTokenState(State):
 
 
     def __init__(self, *args):
-
         super().__init__(*args)
         self.gui = WaitForTokenGui(self.master, self.gui_callback)
         self.token_reader_timer = None
@@ -314,19 +313,17 @@ class WaitForKeyReaderReadyState(State):
 
     def check_key_reader_ready(self):
         try:
-            key_reader = self.application.key_reader.__class__.get_reader()
+            self.application.key_reader = self.application.key_reader.__class__.get_reader()
             self.application.on_event(Event(Event.KEY_READER_CONNECTED))
         except NoReaderFound:
-            pass
-
-        self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
+            self.check_reader_connected_timeout = self.master.after(500, self.check_key_reader_ready)
 
     def on_event(self, event):
         event_type = event.event
         if event_type == Event.KEY_READER_CONNECTED:
             if self.check_reader_connected_timeout is not None:
                 self.master.after_cancel(self.check_reader_connected_timeout)
-            return WaitingState(self.application, self.master, self.member)
+            return WaitingState(self.application, self.master)
 
 class Application(object):
 

--- a/src/util/key_reader.py
+++ b/src/util/key_reader.py
@@ -76,7 +76,7 @@ class EM4100(KeyReader):
         try:
             test_com = serial.Serial(port=self.com.name, baudrate=self.com.baudrate, timeout=0)
             test_com.close()
-            return True
+            return self.com.isOpen()
         except (serial.SerialException, termios.error):
             return False
 

--- a/src/util/key_reader.py
+++ b/src/util/key_reader.py
@@ -9,6 +9,12 @@ logger = get_logger()
 class NoReaderFound(OSError):
     pass
 
+class KeyReaderInitError(IOError):
+    pass
+
+class KeyReaderNeedsRebootError(IOError):
+    pass
+
 def abstract(fun):
     def abstract_wrapper(*args, **kwargs):
         raise NotImplementedError("This is only an abstract function")
@@ -50,7 +56,10 @@ class EM4100(KeyReader):
         logger.info(f"Connecting to serial port {serial_device}")
 
         # Arduino is restarted when serial port is opened
-        self.com = serial.Serial(port=serial_device, baudrate=115200, timeout=2)
+        try:
+            self.com = serial.Serial(port=serial_device, baudrate=115200, timeout=2)
+        except serial.serialutil.SerialException as e:
+            raise KeyReaderNeedsRebootError("Serial port to key reader seems to have hanged. Perhaps unplug it and plug it in again. Reported error: " + str(e))
         com = self.com
         com.readline() # Just wait until it starts up and starts printing something (hopefully less than 2 second timeout)
         com.timeout = 0
@@ -101,8 +110,10 @@ class EM4100(KeyReader):
         com.write(b"?\n")
         com.flush()
         response = com.readline().decode("utf-8")
+        if len(response) == 0:
+            raise KeyReaderInitError("Got no identification reponse from reader")
         if not response.startswith("EM4100 Reader"):
-            logger.error("Response: " + str(response))
+            raise KeyReaderInitError("Wrong response from reader: " + str(response))
         else:
             logger.info(f"Key reader {self} responds")
         com.timeout = previous_timeout
@@ -115,8 +126,8 @@ class EM4100(KeyReader):
         for dev in devices:
             try:
                 key_readers.append(cls(dev))
-            except Exception as e:
-                logger.exception(e)
+            except KeyReaderInitError as e:
+                logger.info(f"Could not initialize {dev} as {cls}. {e}")
 
         return key_readers
 

--- a/src/util/key_reader.py
+++ b/src/util/key_reader.py
@@ -24,6 +24,12 @@ class KeyReader(object):
     def tag_was_read(self):
         return False
 
+    def is_open(self):
+        return True
+
+    def close(self):
+        pass
+
     @classmethod
     def get_reader(cls):
         key_readers = cls.get_devices()
@@ -33,6 +39,8 @@ class KeyReader(object):
         key_reader = key_readers[0]
         if len(key_readers) > 1:
             logger.warning(f"There are several key readers connected: {key_readers}. Chose {key_reader}")
+        for kr in key_readers[1:]:
+            kr.close()
 
         return key_reader
 
@@ -54,6 +62,17 @@ class EM4100(KeyReader):
 
     def flush(self):
         self.com.reset_input_buffer()
+
+    def is_open(self):
+        try:
+            test_com = serial.Serial(port=self.com.name, baudrate=self.com.baudrate, timeout=0)
+            test_com.close()
+            return True
+        except (serial.SerialException, termios.error):
+            return False
+
+    def close(self):
+        self.com.close()
 
     def tag_was_read(self):
         if self.com.in_waiting == 0:


### PR DESCRIPTION
Handling serial port disconnect/reconnect by adding another state in application/GUI. Going back to that state whenever the serial port reports an error (i.e. is disconnected). Then continuously tries to find connected key readers and connect to them again.

This change also makes `memberbooth.py` not crash anymore when the key reader is not found at start, since it is "lazy loaded" at the proper state.

**Note that I have linked two issues to be closed by this pull request**.