### PR TITLE
Update parsing of backend response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,7 @@ $(font_dir)/$(fontfile):
 	unzip -j -o "$(fontzip)" "$(fontfile)" -d "$(font_dir)"
 	rm $(fontzip)
 
-.PHONY=init init-font init-pip
+test:
+	PYTHONPATH="$(shell pwd)" pytest
+
+.PHONY: init init-font init-pip test

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.21.0
 pyserial==3.4
 slackclient==2.5.0
 ansicolors==1.1.8
+pytest

--- a/src/backend/member.py
+++ b/src/backend/member.py
@@ -13,6 +13,9 @@ class NoMatchingMemberNumber(KeyError):
     def __init__(self, member_number):
         super().__init__(f"No member associated with member number: {member_number}")
 
+class BackendParseError(KeyError):
+    pass
+
 @dataclass(frozen=True)
 class EndDate:
     is_active: bool
@@ -35,11 +38,11 @@ class Member(object):
         return f"{self.first_name} {self.last_name}"
 
     def __str__(self):
-        return f'{self.member_number}, {self.get_name()}, {self.lab_end_date}'
+        return f'#{self.member_number}, "{self.get_name()}", {self.membership},{self.effective_labaccess}({self.labaccess}{self.special_labaccess})'
 
     @classmethod
     def from_response(cls, response_data):
-        if (response_data or response_data["data"]) is None:
+        if (response_data and response_data["data"]) is None:
             return None
 
         def datify(makeradmin_date):
@@ -47,17 +50,22 @@ class Member(object):
                 return None
             return datetime.datetime.combine(dateutil.parser.parse(makeradmin_date).date(), datetime.time(23, 59, 59))
 
-        data = response_data["data"]
-        membership_data = data["membership_data"]
+        try:
+            data = response_data["data"]
+            membership_data = data["membership_data"]
 
-        return cls(
-            data["firstname"], data["lastname"],
-            data["member_number"],
-            membership = EndDate(membership_data["membership_active"], datify(membership_data["membership_end"])),
-            labaccess = EndDate(membership_data["labaccess_active"], datify(membership_data["labaccess_end"])),
-            special_labaccess = EndDate(membership_data["special_labaccess_active"], datify(membership_data["special_labaccess_end"])),
-            effective_labaccess = EndDate(membership_data["effective_labaccess_active"], datify(membership_data["effective_labaccess_end"])),
-        )
+            member =  cls(
+                data["firstname"], data["lastname"],
+                data["member_number"],
+                membership = EndDate(membership_data["membership_active"], datify(membership_data["membership_end"])),
+                labaccess = EndDate(membership_data["labaccess_active"], datify(membership_data["labaccess_end"])),
+                special_labaccess = EndDate(membership_data["special_labaccess_active"], datify(membership_data["special_labaccess_end"])),
+                effective_labaccess = EndDate(membership_data["effective_labaccess_active"], datify(membership_data["effective_labaccess_end"])),
+            )
+        except Exception as e:
+            raise BackendParseError(str(e))
+
+        return member
 
     @classmethod
     def from_tagid(cls, client, tagid):

--- a/src/backend/member.py
+++ b/src/backend/member.py
@@ -1,5 +1,6 @@
 import dateutil.parser
 import datetime
+from dataclasses import dataclass
 
 from logging import getLogger
 logger = getLogger("memberbooth")
@@ -12,12 +13,23 @@ class NoMatchingMemberNumber(KeyError):
     def __init__(self, member_number):
         super().__init__(f"No member associated with member number: {member_number}")
 
+@dataclass(frozen=True)
+class EndDate:
+    is_active: bool
+    end_date:  datetime.datetime
+
+    def __str__(self):
+        return "✓" if self.is_active else "✕"
+
+@dataclass(frozen=True)
 class Member(object):
-    def __init__(self, first_name, last_name, member_number, lab_end_date):
-        self.first_name = first_name
-        self.last_name = last_name
-        self.member_number = member_number
-        self.lab_end_date = lab_end_date
+    first_name:          str
+    last_name:           str
+    member_number:       int
+    membership:          EndDate
+    labaccess:           EndDate
+    special_labaccess:   EndDate
+    effective_labaccess: EndDate
 
     def get_name(self):
         return f"{self.first_name} {self.last_name}"
@@ -27,28 +39,39 @@ class Member(object):
 
     @classmethod
     def from_response(cls, response_data):
-        member_data = response_data["data"]["member"]
-        lab_end_date = member_data["end_date"]
-        lab_end_time = None
-        if lab_end_date is not None:
-            lab_end_date = dateutil.parser.parse(lab_end_date).date()
-            lab_end_time = datetime.datetime.combine(lab_end_date, datetime.time(23, 59, 59))
-        return cls(member_data["firstname"], member_data["lastname"], member_data["member_number"], lab_end_time)
+        if (response_data or response_data["data"]) is None:
+            return None
+
+        def datify(makeradmin_date):
+            if makeradmin_date is None:
+                return None
+            return datetime.datetime.combine(dateutil.parser.parse(makeradmin_date).date(), datetime.time(23, 59, 59))
+
+        data = response_data["data"]
+        membership_data = data["membership_data"]
+
+        return cls(
+            data["firstname"], data["lastname"],
+            data["member_number"],
+            membership = EndDate(membership_data["membership_active"], datify(membership_data["membership_end"])),
+            labaccess = EndDate(membership_data["labaccess_active"], datify(membership_data["labaccess_end"])),
+            special_labaccess = EndDate(membership_data["special_labaccess_active"], datify(membership_data["special_labaccess_end"])),
+            effective_labaccess = EndDate(membership_data["effective_labaccess_active"], datify(membership_data["effective_labaccess_end"])),
+        )
 
     @classmethod
     def from_tagid(cls, client, tagid):
-        data = client.get_tag_info(tagid)
-        if data["data"] is None:
+        member = cls.from_response(client.get_tag_info(tagid))
+        if member is None:
             raise NoMatchingTagId(tagid)
 
-        member_data = data["data"]["member"]
-        return cls.from_response(data)
+        return member
 
     @classmethod
     def from_member_number(cls, client, member_number):
-        data = client.get_member_number_info(member_number)
-        if data["data"] is None:
+        member = cls.from_response(client.get_member_number_info(member_number))
+        if member is None:
             raise NoMatchingMemberNumber(member_number)
-        
-        return cls.from_response(data)
+
+        return member
 

--- a/src/gui/design.py
+++ b/src/gui/design.py
@@ -209,7 +209,7 @@ class MemberInformation(GuiTemplate, ButtonsGuiMixin):
     def __init__(self, master, gui_callback, member):
         super().__init__(master, gui_callback)
 
-        self.add_basic_information(self.frame, member.member_number, member.get_name(), str(member.lab_end_date))
+        self.add_basic_information(self.frame, member.member_number, member.get_name(), str(member.effective_labaccess.end_date))
 
 
         self.storage_label_button = self.add_print_button(self.frame,

--- a/src/test/makeradmin_mock.py
+++ b/src/test/makeradmin_mock.py
@@ -1,15 +1,26 @@
 import datetime
 
 response = {
-    "data": {
-        "member": {
-            "end_date": "2019-04-19",
-            "member_number": 9999,
-            "firstname": "Firstname",
-            "lastname": "Lastname"
-        },
+    'data': {
+        'firstname': 'Firstname',
+        'keys': [
+            {'key_id': 1, 'rfid_tag': '123456789'}
+        ],
+        'lastname': 'Lastname',
+        'member_id': 1,
+        'member_number': 9999,
+        'membership_data': {
+            'effective_labaccess_active': True,
+            'effective_labaccess_end': '2020-04-30',
+            'labaccess_active': False,
+            'labaccess_end': '2020-02-19',
+            'membership_active': True,
+            'membership_end': '2020-08-31',
+            'special_labaccess_active': False,
+            'special_labaccess_end': None
+        }
     },
-    "status": "success"
+    'status': 'ok'
 }
 
 class MakerAdminClient(object):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,10 @@
+import unittest
+from src.backend import member, makeradmin
+from src.test import makeradmin_mock
+
+class TestMock(unittest.TestCase):
+    def setUp(self):
+        self.client = makeradmin_mock.MakerAdminClient()
+
+    def test_parse_response(self):
+        m = member.Member.from_tagid(self.client, 0)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,12 @@
 import unittest
 from src.backend import member, makeradmin
 from src.test import makeradmin_mock
+from unittest.mock import patch
+import copy
+
+# Make a deep copy of an object and then restore it afterwards
+def patch_deep_copy(target, template):
+    return patch(target, new_callable=copy.deepcopy, x=template)
 
 class TestMock(unittest.TestCase):
     def setUp(self):
@@ -8,3 +14,22 @@ class TestMock(unittest.TestCase):
 
     def test_parse_response(self):
         m = member.Member.from_tagid(self.client, 0)
+
+    def test_reports_backend_response_errors(self):
+        with self.assertRaises(member.BackendParseError), patch_deep_copy("src.test.makeradmin_mock.response", makeradmin_mock.response) as response:
+            response["data"]["membership_data"] = dict()
+            m = member.Member.from_tagid(self.client, 0)
+
+        with self.assertRaises(member.BackendParseError), patch_deep_copy("src.test.makeradmin_mock.response", makeradmin_mock.response) as response:
+            response["data"]["membership_data"]["membership_end"] = "Not a date"
+            m = member.Member.from_tagid(self.client, 0)
+
+    def test_member_not_found(self):
+        with self.assertRaises(member.NoMatchingMemberNumber), patch_deep_copy("src.test.makeradmin_mock.response", makeradmin_mock.response) as response:
+            response["data"] = None
+            m = member.Member.from_member_number(self.client, 1000)
+
+    def test_tag_not_found(self):
+        with self.assertRaises(member.NoMatchingTagId), patch_deep_copy("src.test.makeradmin_mock.response", makeradmin_mock.response) as response:
+            response["data"] = None
+            m = member.Member.from_tagid(self.client, 1000)


### PR DESCRIPTION
Updated so that Memberbooth works with the updated backend (where the correct and additional information is returned about the member).

New data that is returned (both if it is active and the end date):
* Membership
* Lab access
* Effective lab access
* Special access

Closes #61 
Closes #54 