### PR TITLE
Network request timeout

### DIFF
--- a/src/backend/makeradmin.py
+++ b/src/backend/makeradmin.py
@@ -6,7 +6,7 @@ from src.util.token_config import TokenConfiguredClient, TokenExpiredError
 logger = get_logger()
 
 
-class NetworkError(BaseException):
+class NetworkError(Exception):
     pass
 
 
@@ -36,8 +36,8 @@ class MakerAdminClient(TokenConfiguredClient):
         try:
             r = requests.get(url, headers={'Authorization': 'Bearer ' + self.token}, data=data, timeout=1)
         except requests.exceptions.RequestException as e:
-            logger.error(e)
-            raise NetworkError
+            logger.exception("An exception was raised while trying to send request to makeradmin")
+            raise NetworkError()
         return r
 
     @TokenConfiguredClient.require_configured_factory(default_retval=dict(ok=False))
@@ -50,7 +50,7 @@ class MakerAdminClient(TokenConfiguredClient):
         r = self._request(self.TAG_URL, {"tagid": 0})
         if not r.ok:
             data = r.json()
-            logger.info(f"Token not logged in with correct permissions. Got: '{data}'")
+            logger.warning(f"Token not logged in with correct permissions. Got: '{data}'")
         return r.ok
 
     def get_tag_info(self, tagid: int):

--- a/src/backend/makeradmin.py
+++ b/src/backend/makeradmin.py
@@ -2,7 +2,12 @@ import requests
 from src.util.logger import get_logger
 from src.util.token_config import TokenConfiguredClient, TokenExpiredError
 
+
 logger = get_logger()
+
+
+class NetworkError(BaseException):
+    pass
 
 
 class MakerAdminTokenExpiredError(TokenExpiredError):
@@ -28,7 +33,11 @@ class MakerAdminClient(TokenConfiguredClient):
 
     def _request(self, subpage, data={}):
         url = self.base_url + subpage
-        r = requests.get(url, headers={'Authorization': 'Bearer ' + self.token}, data=data)
+        try:
+            r = requests.get(url, headers={'Authorization': 'Bearer ' + self.token}, data=data, timeout=1)
+        except requests.exceptions.RequestException as e:
+            logger.error(e)
+            raise NetworkError
         return r
 
     @TokenConfiguredClient.require_configured_factory(default_retval=dict(ok=False))

--- a/src/backend/makeradmin.py
+++ b/src/backend/makeradmin.py
@@ -35,7 +35,7 @@ class MakerAdminClient(TokenConfiguredClient):
         url = self.base_url + subpage
         try:
             r = requests.get(url, headers={'Authorization': 'Bearer ' + self.token}, data=data, timeout=1)
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException:
             logger.exception("An exception was raised while trying to send request to makeradmin")
             raise NetworkError()
         return r

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -5,7 +5,7 @@ from time import time
 import serial.serialutil
 
 import config
-from src.backend.makeradmin import MakerAdminTokenExpiredError
+from src.backend.makeradmin import MakerAdminTokenExpiredError, NetworkError
 from src.backend.member import Member, NoMatchingTagId
 from src.label import creator as label_creator
 from src.label import printer as label_printer
@@ -160,6 +160,9 @@ class WaitingState(State):
                 self.gui.show_error_message("Could not find a member that matches the specific tag")
             except MakerAdminTokenExpiredError:
                 return WaitingForTokenState(self, self.member)
+            except NetworkError:
+                self.gui.reset_gui()
+                self.gui.show_error_message("Network error, please try again")
             except Exception as e:
                 logger.exception("Unexpected exception")
                 self.gui.show_error_message(f"Error... \n{e}")

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -311,6 +311,7 @@ class WaitingForTokenState(State):
                 self.token_reader_timer_start()
         except Exception:
             logger.exception("Exception while waiting for makeradmin token")
+            self.token_reader_timer_start()
 
     def token_reader_timer_start(self):
         self.token_reader_timer = self.master.after(1000, self.token_reader_timer_expired)

--- a/src/gui/states.py
+++ b/src/gui/states.py
@@ -309,6 +309,10 @@ class WaitingForTokenState(State):
                 self.application.on_event(Event(Event.MAKERADMIN_CLIENT_CONFIGURED))
             else:
                 self.token_reader_timer_start()
+        except NetworkError:
+            logger.error("Network error. Cannot connect to login server.")
+            self.gui.show_error_message("Network error. Cannot connect to login server.")
+            self.token_reader_timer_start()
         except Exception:
             logger.exception("Exception while waiting for makeradmin token")
             self.token_reader_timer_start()


### PR DESCRIPTION
Adds error handling of network problems and prints error on network problems while trying to verify token.

Closes #82 