### PR TITLE
Adding a QR code to the temporary storage label

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -6,10 +6,40 @@ name: Python 3.8 test action
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
-
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          make init-font
+      - name: Flake8 test
+        run: |
+          make flake8
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          make init-font
+      - name: Test with pytest
+        run: |
+          make test
+  generate-example-images:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
@@ -21,16 +51,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         make init-font
-    - name: Test with pytest
-      run: |
-        make test
-    - name: Flake8 test
-      run: |
-        make flake8
-
     - name: Generate example images
       run: |
-        python print_box_label.py --no-backend --no-printer 1000
+        python print_box_label.py --no-backend --no-printer 9999
         ( echo "y" && echo "y" && echo ) | python print_warning_label.py --no-printer
     - name: Upload image artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Generate example images
       run: |
         python print_box_label.py --no-backend --no-printer 9999
+        python print_temporary_storage_label.py --no-backend --no-printer 9999 "qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu qwertyu "
         ( echo "y" && echo "y" && echo ) | python print_warning_label.py --no-printer
     - name: Upload image artifacts
       uses: actions/upload-artifact@v2

--- a/print_temporary_storage_label.py
+++ b/print_temporary_storage_label.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 from src.util.logger import init_logger, get_logger
-init_logger("print_temporary_storage_label")
-logger = get_logger()
-
 import argparse
 from src.label import creator as label_creator
 from src.label import printer as label_printer
@@ -13,12 +10,16 @@ from src.test import makeradmin_mock
 import config
 import sys
 
+init_logger("print_temporary_storage_label")
+logger = get_logger()
+
+
 start_command = " ".join(sys.argv)
 
 
 def print_label(label, no_printer: bool = False):
     if no_printer:
-        file_name = f'warning_label_{str(int(time()))}.png'
+        file_name = f'temporary_storage_label_{int(time())}.png'
         logger.info(
             f'Program run with --no-printer, storing label image to {file_name} instead of printing it.')
         print(f"Saving warning label to {file_name}")

--- a/print_temporary_storage_label.py
+++ b/print_temporary_storage_label.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import argparse
+from src.label import creator as label_creator
+from src.label import printer as label_printer
+from time import time
+from src.util.logger import init_logger, get_logger
+from src.backend.member import Member
+from src.backend import makeradmin
+from src.test import makeradmin_mock
+import config
+import sys
+
+init_logger("print_temporary_storage_label")
+logger = get_logger()
+start_command = " ".join(sys.argv)
+
+
+def print_label(label, no_printer: bool = False):
+    if no_printer:
+        file_name = f'warning_label_{str(int(time()))}.png'
+        logger.info(
+            f'Program run with --no-printer, storing label image to {file_name} instead of printing it.')
+        print(f"Saving warning label to {file_name}")
+        label.save(file_name)
+        label.show()
+    else:
+        label_printer.print_label(label.label)
+
+
+def main():
+    logger.info(f"Starting {sys.argv[0]} as \n\t{start_command}")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-printer", action="store_true", help="Mock label printer (save label to file instead)")
+    parser.add_argument("--no-backend", action="store_true", help="Do not use the makeradmin backend")
+    parser.add_argument("member_id", type=int, help="The member number")
+    parser.add_argument("description", help="The description of the temporary storage label")
+
+    args = parser.parse_args()
+    config.no_printer = args.no_printer
+
+    if args.no_backend:
+        makeradmin_client = makeradmin_mock.MakerAdminClient()
+    else:
+        makeradmin_client = makeradmin.MakerAdminClient(base_url=config.maker_admin_base_url,
+                                                        token_path=config.token_path)
+    while not makeradmin_client.is_logged_in():
+        logger.warning("The makeradmin client is not logged in")
+        makeradmin_client.login()
+
+    member = Member.from_member_number(makeradmin_client, args.member_id)
+    label = label_creator.create_temporary_storage_label(args.member_id, member.get_name(), args.description)
+    print_label(label, args.no_printer)
+
+
+if __name__ == "__main__":
+    main()

--- a/print_temporary_storage_label.py
+++ b/print_temporary_storage_label.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
+from src.util.logger import init_logger, get_logger
+init_logger("print_temporary_storage_label")
+logger = get_logger()
 
 import argparse
 from src.label import creator as label_creator
 from src.label import printer as label_printer
 from time import time
-from src.util.logger import init_logger, get_logger
 from src.backend.member import Member
 from src.backend import makeradmin
 from src.test import makeradmin_mock
 import config
 import sys
 
-init_logger("print_temporary_storage_label")
-logger = get_logger()
 start_command = " ".join(sys.argv)
 
 

--- a/src/label/creator.py
+++ b/src/label/creator.py
@@ -104,6 +104,9 @@ class LabelImage(LabelObject):
             self.image = Image.open(image)
         else:
             self.image = image
+        width, height = self.image.size
+        new_height = int(label_width / width * height)
+        self.image = self.image.resize((label_width, new_height), Image.ANTIALIAS)
 
         self.height = self.image.size[1]
         self.width = self.image.size[0]

--- a/src/label/creator.py
+++ b/src/label/creator.py
@@ -11,10 +11,10 @@ import config
 logger = get_logger()
 
 QR_CODE_BOX_SIZE = 15  # Pixel size per box.
-QR_CODE_VERSION = 5  # Support for 64  alphanumeric with high error correction
+QR_CODE_VERSION = None  # Auto-resize QR code
 QR_CODE_BORDER = 0
-QR_CODE_ERROR_CORRECTION = qrcode.constants.ERROR_CORRECT_L
-QR_CODE_DESCRIPTION_MAX_LENGTH = 40
+QR_CODE_ERROR_CORRECTION = qrcode.constants.ERROR_CORRECT_M
+QR_CODE_DESCRIPTION_MAX_LENGTH = 100
 
 IMG_WIDTH = 696  # From brother_ql for 62 mm labels
 IMG_HEIGHT = math.floor((58 + 20) / 25.4 * 300)

--- a/src/label/creator.py
+++ b/src/label/creator.py
@@ -1,5 +1,5 @@
 import qrcode
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 from time import time
 from src.util.logger import get_logger
 import json

--- a/src/label/creator.py
+++ b/src/label/creator.py
@@ -282,13 +282,13 @@ def get_font_size_estimation(text):
 def create_temporary_storage_label(member_id: int, name: str, description: str):
     end_date_str = get_end_date_string(TEMP_STORAGE_LENGTH)
     data_json = json.dumps({
-            JSON_MEMBER_NUMBER_KEY: member_id,
-            JSON_VERSION_KEY: QR_VERSION_TEMP_STORAGE_LABEL,
-            JSON_TYPE_KEY: JSON_TYPE_VALUE_TEMP_STORAGE,
-            JSON_EXPIRY_DATE_KEY: end_date_str,
-            JSON_UNIX_TIMESTAMP_KEY: get_unix_timestamp(),
-            JSON_DESCRIPTION_KEY: textwrap.shorten(description, width=QR_CODE_DESCRIPTION_MAX_LENGTH)
-        },
+        JSON_MEMBER_NUMBER_KEY: member_id,
+        JSON_VERSION_KEY: QR_VERSION_TEMP_STORAGE_LABEL,
+        JSON_TYPE_KEY: JSON_TYPE_VALUE_TEMP_STORAGE,
+        JSON_EXPIRY_DATE_KEY: end_date_str,
+        JSON_UNIX_TIMESTAMP_KEY: get_unix_timestamp(),
+        JSON_DESCRIPTION_KEY: textwrap.shorten(description, width=QR_CODE_DESCRIPTION_MAX_LENGTH)
+    },
         indent=None, separators=(',', ':')
     )
     logger.info(f"Creating a QR code for temporary storage with data: {data_json}")


### PR DESCRIPTION
Temporary storage label with QR code. Stores the following data in the QR code:

```json
{"member_number":9999,"v":1,"type":"temp","expiry_date":"2021-12-24","unix_timestamp":1632602525,"description":"asd ads asd asdasds"}
```

Example:

![image](https://user-images.githubusercontent.com/7572427/134785618-9c0408bb-ddcc-426b-8cf7-ea70366dfd6c.png)


Closes #89 