### PR TITLE
Fix/87 annoying error popup

### DIFF
--- a/src/gui/design.py
+++ b/src/gui/design.py
@@ -6,6 +6,7 @@ from src.util.logger import get_logger
 from src.util.key_reader import EM4100, Aptus, Keyboard
 from re import compile, sub
 import config
+from typing import Union
 from datetime import datetime
 from .event import GuiEvent
 
@@ -38,18 +39,30 @@ class GuiTemplate:
         entry.config(state=DISABLED)
         return entry
 
-    def create_label_with_status_indicator(self, master, label_text, text, is_expired):
+    def create_label_with_status_indicator(self, master, label_text, dt: Union[datetime, None]):
 
         holder = Frame(master, background='')
 
         label = self.create_label(master, label_text)
         label.pack(fill=X, pady=5)
 
-        status_label = self.create_label(holder, 'X' if is_expired else "✓")
-        status_label.configure(fg="red" if is_expired else "green")
+        expiration_text = str(dt)
+        if dt is None:
+            text = "?"
+            color = "red"
+            expiration_text = "Unknown"
+        elif datetime.now() > dt:
+            text = 'X'
+            color = "red"
+        else:
+            text = "✓"
+            color = "green"
+
+        status_label = self.create_label(holder, text)
+        status_label.configure(fg=color)
         status_label.pack(side=LEFT, padx=5)
 
-        tag_expiration_text = self.create_entry(holder, text, border=False)
+        tag_expiration_text = self.create_entry(holder, expiration_text, border=False)
         tag_expiration_text.pack(fill=X)
 
         return holder
@@ -70,11 +83,10 @@ class GuiTemplate:
 
         now = datetime.now()
         membership_status = self.create_label_with_status_indicator(master, "Organization membership expires:",
-                                                                    membership_expiration_date,
-                                                                    now > membership_expiration_date)
+                                                                    membership_expiration_date)
         membership_status.pack(fill=X, pady=5)
         lab_membership_status = self.create_label_with_status_indicator(master, 'Lab membership expires:',
-                                                                        tag_expiration_date, now > tag_expiration_date)
+                                                                        tag_expiration_date)
         lab_membership_status.pack(fill=X, pady=5)
 
     def __init__(self, master, gui_callback):

--- a/src/gui/design.py
+++ b/src/gui/design.py
@@ -304,6 +304,14 @@ class TemporaryStorage(GuiTemplate, ButtonsGuiMixin):
 
         self.character_label_update()
 
+    def show_error_message(self, error_message, error_title='Error'):
+        logger.error(f"GUI error: {error_message}")
+        if self.error_message_debouncer is not None:
+            self.frame.after_cancel(self.error_message_debouncer)
+        self.error_message_label.config(text=error_message)
+        self.error_message_debouncer = self.frame.after(5000, lambda: self.error_message_label.config(text=''))
+        return
+
     def character_label_update(self):
         text_box_content = self.text_box.get('1.0', END)
         text_box_length = len(text_box_content) - 1
@@ -337,6 +345,7 @@ class TemporaryStorage(GuiTemplate, ButtonsGuiMixin):
 
         self.text_box.bind('<FocusIn>', self.text_box_callback_focusin)
         self.text_box.pack()
+        self.error_message_debouncer = None
 
         self.print_button = self.add_print_button(
             self.frame,
@@ -351,6 +360,10 @@ class TemporaryStorage(GuiTemplate, ButtonsGuiMixin):
         )
 
         self.buttons = [self.print_button, self.cancel_button]
+
+        self.error_message_label = self.create_label(self.frame, '')
+        self.error_message_label.config(fg='red')
+        self.error_message_label.pack(fill=X, pady=5)
 
         self.frame.pack(pady=25)
 


### PR DESCRIPTION
## Two fixes:

1. Crash when user has never had membership. Instead, we now show it as an "unknown" date:
    ![image](https://user-images.githubusercontent.com/7572427/135163493-06aa9112-77bf-457d-84c7-3be64e98d8ed.png)

2. Annoying pop-up dialog in temporary storage GUI turned into red error message that auto-hides:
    ![image](https://user-images.githubusercontent.com/7572427/135163778-503edd11-e106-4c7f-bdb7-498d77760087.png)

Closes #87 

